### PR TITLE
This commit was meant to get all of the tests under t/array pass

### DIFF
--- a/src/classes/Array.pir
+++ b/src/classes/Array.pir
@@ -1371,7 +1371,7 @@ Retrieve the number of elements in C<self>
 
     $I0 = 0 
   range_loop:
-    if $I0 > count goto done
+    if $I0 >= count goto done
     $I1 = $I0 + beg
     if $I1 == len goto range_outofrange
     val = a[$I1]
@@ -1536,7 +1536,7 @@ Retrieve the number of elements in C<self>
     end = r.'to'()
 
     $P0 = getattribute r, '$!to_exclusive'
-    unless $P0 goto skip_exclusive_to
+    if $P0 goto skip_exclusive_to
     inc end
 
   skip_exclusive_to:

--- a/src/classes/Object.pir
+++ b/src/classes/Object.pir
@@ -276,7 +276,8 @@ Create a clone of self, also cloning the attributes given by attrlist.
     $S0 = shift attr_it
     unless $S0 goto attr_loop
     $P1 = getattribute self, $S0
-    unless $P1 goto set_default
+    $I0 = defined $P1
+    unless $I0 goto set_default
     $P1 = clone $P1
     setattribute result, $S0, $P1
     goto attr_loop

--- a/src/classes/Range.pir
+++ b/src/classes/Range.pir
@@ -328,7 +328,7 @@ Generate the next element at the front of the CardinalRange.
     fromexc = getattribute self, '$!from_exclusive'
     value = clone from
     inc from
-    unless fromexc > 0 goto have_value
+    unless fromexc goto have_value
     value = clone from
   have_value:
     $I0 = self.'!to_test'(value)
@@ -350,7 +350,7 @@ Return true if there are any more values to iterate over.
     .local pmc from, fromexc
     from = getattribute self, '$!from'
     fromexc = getattribute self, '$!from_exclusive'
-    unless fromexc > 0 goto have_value
+    unless fromexc goto have_value
     from = clone from
     inc from
   have_value:
@@ -370,8 +370,7 @@ Return true if there are any more values to iterate over.
     setattribute self, '$!to_exclusive', $P2
     goto finish
     default:
-        $P0 = new 'CardinalInteger'
-        $P0 = 0
+        $P0 = new 'FalseClass'
         setattribute self, '$!from_exclusive', $P0
         setattribute self, '$!to_exclusive', $P0
         goto finish
@@ -385,8 +384,7 @@ Return true if there are any more values to iterate over.
 .sub 'initialize' :method :multi(_,_,_)
     .param pmc from
     .param pmc to
-    $P0 = new 'CardinalInteger'
-    $P0 = 0
+    $P0 = new 'FalseClass'
     setattribute self, '$!from_exclusive', $P0
     setattribute self, '$!to_exclusive', $P0
     setattribute self, '$!from', from
@@ -480,7 +478,7 @@ honoring exclusive flags.
     .local pmc from, fromexc
     from = getattribute self, '$!from'
     fromexc = getattribute self, '$!from_exclusive'
-    if fromexc > 0 goto exclusive_test
+    if fromexc goto exclusive_test
     $I0 = isge topic, from
     .return ($I0)
   exclusive_test:
@@ -503,7 +501,7 @@ honoring exclusive flags.
     .return ($I0)
   test_value:
     toexc = getattribute self, '$!to_exclusive'
-    if toexc > 0 goto exclusive_test
+    if toexc goto exclusive_test
     $I0 = isle topic, to
     .return ($I0)
   exclusive_test:


### PR DESCRIPTION
Initializes Range!from_exclusive and Range!to_exclusive as FalseClass instead of CardinalInteger.
And a few bugs in Array.pir are fixed.

So now, that the failed tests of t/array/assign.t, t/array/values_at.t, t/continuation.t and t/range/infix-exclusive.t
all pass.
