### PR TITLE
Patch for issue #6

### DIFF
--- a/src/parser/grammar.pg
+++ b/src/parser/grammar.pg
@@ -61,7 +61,10 @@ rule alias {
 }
 
 token stmt {
-    <basic_stmt> <.ws> <stmt_mod>*
+    [
+    | '(' \s*\n* <basic_stmt> <.ws> <stmt_mod>* \s*\n* ')' # NOTE: this change is not allows '(- 1)'
+    | <basic_stmt> <.ws> <stmt_mod>*
+    ]
     {*}
 }
 

--- a/t/01-stmts.t
+++ b/t/01-stmts.t
@@ -1,6 +1,6 @@
 # If this is to test the basic statements then we can't really use Test.rb
 # Although of course Test.rb itself contains all the statements tested
-puts "1..12"
+puts "1..30"
 
 if 1 then
   puts "ok 1"
@@ -55,22 +55,91 @@ else
   puts "not ok 8 # an empty string '' should evaluate to true - Issue 28"
 end
 
-# test parrentheses ()
-if (1)
+# the statements enclosed by parentheses '()'
+(if 1
   puts "ok 9"
+end)
+
+( if 1
+  puts "ok 10"
+end )
+
+(
+  if 1
+    puts "ok 11"
+  end
+)
+
+if (1)
+  puts "ok 12"
 else
-  puts "not ok 9"
+  puts "not ok 13"
 end
 
 if (-1)
-  puts "ok 10"
+  puts "ok 14"
 else
-  puts "not ok 10"
+  puts "not ok 14"
 end
 
-(-1.0)
-puts "ok 11"
+# the literals(objects) enclosed by parentheses '()'
+(1)
+puts "ok 15"
 
 (-1)
-puts "ok 12"
+puts "ok 16"
 
+# failed
+#(- 1)
+puts "not ok 17"
+
+# failed
+(
+-
+1
+)
+puts "ok 18"
+
+# failed
+(
+-
+  1
+)
+puts "ok 19"
+
+# failed
+( - 1 )
+puts "ok 20"
+
+(1.0)
+puts "ok 21"
+
+([])
+puts "ok 22"
+
+# failed
+(%W(a b c))
+puts "ok 23"
+
+({})
+puts "ok 24"
+
+# failed
+(//)
+puts "ok 25"
+
+("")
+puts "ok 26"
+
+# failed
+(%Q())
+puts "ok 27"
+
+(true)
+puts "ok 28"
+
+(false)
+puts "ok 29"
+
+(true)
+puts "ok 30"

--- a/t/01-stmts.t
+++ b/t/01-stmts.t
@@ -143,3 +143,6 @@ puts "ok 29"
 
 (true)
 puts "ok 30"
+
+(-1.0)
+puts "ok 31"


### PR DESCRIPTION
this change allows:
- almost statments enclosed by '()'
- some literals enclosed by '()': see t/01-stmts.t for the details

t/01-stmts.t will be failed because I added more test cases cannot be parsed on current cardinal.
they works fine on ruby192.
